### PR TITLE
install_docker.sh: Add vagrant user to docker group

### DIFF
--- a/provisioning/install_docker.sh
+++ b/provisioning/install_docker.sh
@@ -16,5 +16,7 @@ else
     dnf install -y https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
 fi
 
+[ -d /home/vagrant ] && usermod -a -G docker vagrant
+
 systemctl disable firewalld   ;  # yuck!
 systemctl enable --now docker


### PR DESCRIPTION
While provisioning docker (via Vagrant), include vagrant user as
part of the docker group.