### PR TITLE
ovn_cluster.sh start: configure vms using dhcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
 .vagrant
 dbus.service
-ovs/
+/ovs
+/ovn
+_ovn_remote

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ SCRIPT
 
 $build_images = <<SCRIPT
 cd /vagrant && \
-OVN_SRC_PATH=${HOME}/ovn OVS_SRC_PATH=${HOME}/ovs time ./ovn_cluster.sh build
+OVN_SRC_PATH=./ovn OVS_SRC_PATH=./ovs time ./ovn_cluster.sh build
 SCRIPT
 
 $start_ovn_cluster = <<SCRIPT
@@ -27,6 +27,7 @@ Vagrant.configure(2) do |config|
 
     config.vm.hostname = "ovnhostvm"
     config.vm.box = "centos/8"
+    config.vm.box_check_update = false
 
     # config.vm.synced_folder "#{ENV['PWD']}", "/vagrant", sshfs_opts_append: "-o nonempty", disabled: false, type: "sshfs"
     # Optional: Uncomment line above and comment out the line below if you have
@@ -43,6 +44,10 @@ Vagrant.configure(2) do |config|
     config.vm.provision :shell do |shell|
         shell.privileged = false
         shell.path = 'provisioning/grab_ovn_src.sh'
+    end
+
+    config.vm.provision :shell do |shell|
+        shell.path = 'provisioning/enable_nesting.sh'
     end
 
     config.vm.provision :shell do |shell|

--- a/fedora/ovn/Dockerfile
+++ b/fedora/ovn/Dockerfile
@@ -13,7 +13,13 @@ COPY install_ovn.sh /install_ovn.sh
 
 RUN /install_ovn.sh $USE_OVN_RPMS
 
-RUN dnf -y remove automake make gcc autoconf openssl-devel libtool
+# Generate variation of dhclient-script that we can use for fake vm namespaces
+RUN dnf -y install dhclient which
+COPY fedora/ovn/generate_dhclient_script_for_fullstack.sh /tmp/generate_dhclient_script_for_fullstack.sh
+COPY fedora/ovn/install_dhclient_script.sh /tmp/install_dhclient_script.sh
+RUN /tmp/install_dhclient_script.sh /
+
+RUN dnf -y remove automake make gcc autoconf openssl-devel libtool which
 
 VOLUME ["/var/log/openvswitch", \
 "/var/lib/openvswitch", "/var/run/openvswitch", "/etc/openvswitch", \

--- a/fedora/ovn/generate_dhclient_script_for_fullstack.sh
+++ b/fedora/ovn/generate_dhclient_script_for_fullstack.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copied from openstack/neutron
+# - https://github.com/openstack/neutron/blob/stable/train/tools/generate_dhclient_script_for_fullstack.sh
+
+MAKE_RESOLV_CONF_FUNCTION=make_resolv_conf
+
+USAGE="$0 <path to virtual environment to place executable>
+The script takes existing dhclient-script and makes $MAKE_RESOLV_CONF_FUNCTION function a noop function.
+"
+
+if [ $# -lt 1 ]; then
+    echo "Path to virtual environment directory is a required parameter."
+    echo $USAGE
+    exit 2
+fi
+
+VENV_DIR=$1
+DHCLIENT_SCRIPT_NAME=dhclient-script
+DHCLIENT_PATH=$(which $DHCLIENT_SCRIPT_NAME)
+FULLSTACK_DHCLIENT_SCRIPT=$VENV_DIR/bin/fullstack-dhclient-script
+
+if [ -n "$DHCLIENT_PATH" ]; then
+    # Return from make_resolv_conf function immediately. This will cause
+    # that /etc/resolv.conf will not be updated by fake fullstack machines.
+    sed "/^$MAKE_RESOLV_CONF_FUNCTION()/a\    return" $DHCLIENT_PATH > $FULLSTACK_DHCLIENT_SCRIPT
+    chmod +x $FULLSTACK_DHCLIENT_SCRIPT
+else
+    echo "$DHCLIENT_SCRIPT_NAME not found."
+    exit 1
+fi

--- a/fedora/ovn/install_dhclient_script.sh
+++ b/fedora/ovn/install_dhclient_script.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit
+#set -o xtrace
+
+mkdir -pv /bin
+cd "$(dirname $0)"
+./generate_dhclient_script_for_fullstack.sh /

--- a/provisioning/enable_nesting.sh
+++ b/provisioning/enable_nesting.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+#set -o xtrace
+
+[ -e /dev/kvm ] || { echo "PROBLEM, you need to ensure hv can nest"; exit 1; }
+grep -q Y /sys/module/kvm_intel/parameters/nested || {
+  sudo rmmod kvm-intel
+  sudo sh -c "echo 'options kvm-intel nested=y' >> /etc/modprobe.d/dist.conf"
+  sudo modprobe kvm-intel
+}
+[ -e /sys/module/kvm_intel ] && {
+  modinfo kvm_intel | grep -q 'nested:bool' || { echo "PROBLEM, nesting did not enable"; exit 1; }
+} ||:
+

--- a/provisioning/install_docker.sh
+++ b/provisioning/install_docker.sh
@@ -18,5 +18,5 @@ fi
 
 [ -d /home/vagrant ] && usermod -a -G docker vagrant
 
-systemctl disable firewalld   ;  # yuck!
+systemctl disable firewalld ||:  ;  # yuck!
 systemctl enable --now docker

--- a/provisioning/install_ovs_in_underlay.sh
+++ b/provisioning/install_ovs_in_underlay.sh
@@ -6,7 +6,7 @@ set -o xtrace
 set -o errexit
 
 dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-curl -L http://trunk.rdoproject.org/centos7/delorean-deps.repo | sudo tee /etc/yum.repos.d/delorean-deps.repo
+curl -L http://trunk.rdoproject.org/centos8/delorean-deps.repo | sudo tee /etc/yum.repos.d/delorean-deps.repo
 
 ##dnf install -y libibverbs
 ##dnf install -y openvswitch openvswitch-ovn-central openvswitch-ovn-host


### PR DESCRIPTION
This change creates some fake vm ports that use dhcp client in order
to get an ip from ovn. In order to do that, we need a tweak in dhcpc
script to neuter hostname. That tweak is done during container image
creation.

Also enhanced Vagrant provisioning to enable vm nesting. That is now
available on OSX systems with Virtualbox 6.1 or newer.