### PR TITLE
make_container_links.sh: helper for looking at container mounts

### DIFF
--- a/provisioning/make_container_links.sh
+++ b/provisioning/make_container_links.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+[ $EUID -eq 0 ] || { echo 'must be root' >&2; exit 1; }
+
+# make_container_links.sh
+#
+# This script uses mounts from docker inspect and creates
+# symbolic links for all directories it finds under $BASE_DIR
+#
+# Usage: $0 [BASE_DIR]
+#
+
+#set -o xtrace
+set -o errexit
+
+BASE_DIR=${1:-'/tmp/cmounts'}
+SAFE_CHECK_FILE="${BASE_DIR}/$(basename $0).washere"
+[ ! -e ${BASE_DIR} ] || [ -e "${SAFE_CHECK_FILE}" ] || { echo "cowardly bailing: ${SAFE_CHECK_FILE} not found" >&2; exit 1; }
+rm -rf ${BASE_DIR} ; mkdir -p ${BASE_DIR} ; touch "${SAFE_CHECK_FILE}"
+
+for CID in $(docker ps --no-trunc --quiet); do
+    CNAME=$(docker ps --no-trunc --filter "id=${CID}" --format {{.Names}})
+    MOUNTS=$(docker inspect ${CID} | grep -B1 '"Destination": "/' | grep -A1 '"Source": "/' | tr -d [:space:])
+    echo "Creating mount links: ${BASE_DIR}/${CNAME}"
+    mkdir -p "${BASE_DIR}/${CID}"
+    [ -n "${CNAME}" ] && ln -s ${CID} "${BASE_DIR}/${CNAME}"
+    delimiter='Source":'
+    string=$MOUNTS$delimiter
+    myarray=()
+    while [[ $string ]]; do
+	myarray+=( "${string%%"$delimiter"*}" )
+	string=${string#*"$delimiter"}
+    done
+    for value in ${myarray[@]}; do
+        CONTAINER_PATH=$(echo "$value" | cut -d\" -f6)
+	CONTAINER_DIR=$(dirname "$CONTAINER_PATH")
+	CONTAINER_BASE=$(basename "$CONTAINER_PATH")
+	DEST_DIR=$(echo "$value" | cut -d\" -f2)
+	[ -n "${CONTAINER_BASE}" ] && [ -d "${DEST_DIR}" ] && {
+	    mkdir -p "${BASE_DIR}/${CID}${CONTAINER_DIR}"
+	    ln -s "${DEST_DIR}" "${BASE_DIR}/${CID}/${CONTAINER_PATH}" ||:
+	}
+    done
+done


### PR DESCRIPTION
Adding make_container_links.sh as a handy helper for looking at
the directories mounted under docker.

Usage is simple: once containers are running, invoke make_container_links.sh
That will build a tree under /tmp/cmounts (by default) and add symbolic
links to whatever docker gives back as mount from the inspect output of
the currently running containers.