### PR TITLE
ovn_cluster.sh: require super powers

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure(2) do |config|
         shell.path = 'provisioning/install_docker.sh'
     end
 
-    config.vm.provision "build_images", type: "shell", inline: $build_images, privileged: false
+    config.vm.provision "build_images", type: "shell", inline: $build_images, privileged: true
 
     # Install and start ovs used to interconnect the docker
     # containers that are used to emulate the ovn chassis (below). This does not need

--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+[ $EUID -eq 0 ] || { echo 'must be root' >&2; exit 1; }
+
 #set -o xtrace
 set -o errexit
 
-RUNC_CMD="${RUNC_CMD:-sudo docker}"
+RUNC_CMD="${RUNC_CMD:-docker}"
 
 BASE_IMAGE="ovn/cinc"
 CENTRAL_IMAGE="ovn/ovn-multi-node"


### PR DESCRIPTION
As described in
https://github.com/ovn-org/ovn-fake-multinode/issues/24
"sudo docker" instead of "docker" makes scaling tests run a
lot slower. This can cause wasted time when scaling to big
number of interfaces.

Since we already documented uses of this script to be done
by root, this patch removes the sudo prefix in RUNC_CMD and
adds a check right at the top to ensure that the effective
user is root.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Closes ovn-org/ovn-fake-multinode#24