### PR TITLE
Add support for building utilities from sources.

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -114,6 +114,8 @@ yum -y --skip-broken install\
 	which\
 	fping\
 	perf\
+	git\
+	lksctp-tools-devel\
 	hostname
 
 

--- a/fedora/ovn/Dockerfile
+++ b/fedora/ovn/Dockerfile
@@ -5,14 +5,17 @@ ARG OVS_SRC_PATH
 ARG OVN_SRC_PATH
 ARG USE_OVN_RPMS
 ARG EXTRA_OPTIMIZE
+ARG INSTALL_UTILS_FROM_SOURCES
 
 COPY $OVS_SRC_PATH /ovs
 COPY $OVN_SRC_PATH /ovn
 
 COPY *.rpm /
 COPY install_ovn.sh /install_ovn.sh
+COPY install_utils_from_sources.sh /install_utils_from_sources.sh
 
 RUN /install_ovn.sh $USE_OVN_RPMS $EXTRA_OPTIMIZE
+RUN /install_utils_from_sources.sh $INSTALL_UTILS_FROM_SOURCES
 
 
 VOLUME ["/var/log/openvswitch", \

--- a/install_utils_from_sources.sh
+++ b/install_utils_from_sources.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o errexit
+
+install_utils=$1
+if [ "$install_utils" != "yes" ]; then
+    exit 0
+fi
+
+# Use this script to install any utilities from sources.
+
+mkdir -p /root/utilities
+
+# Install uperf
+pushd /root/utilities
+git clone https://github.com/uperf/uperf.git uperf_git
+pushd uperf_git
+./configure --prefix=/root/utilities/uperf_install
+make -j$(($(nproc) + 1))
+make install
+popd
+
+git clone https://github.com/perftool-incubator/bench-uperf bench-uperf_git
+sed -i 's/^exec >uperf-client-stderrout.txt/#exec >uperf-client-stderrout.txt/g' ./bench-uperf_git/uperf-client
+sed -i 's/^exec 2>&1/#exec 2>&1/g' ./bench-uperf_git/uperf-client
+
+popd

--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -56,6 +56,7 @@ CREATE_FAKE_VMS="${CREATE_FAKE_VMS:-yes}"
 SSL_CERTS_PATH="/opt/ovn"
 
 FAKENODE_MNT_DIR="${FAKENODE_MNT_DIR:-/tmp/ovn-multinode}"
+INSTALL_UTILS_FROM_SOURCES="${INSTALL_UTILS_FROM_SOURCES:-no}"
 
 function check-selinux() {
   if [[ "$(getenforce)" = "Enforcing" ]]; then
@@ -692,6 +693,7 @@ function build-images() {
     ${RUNC_CMD} build -t ovn/ovn-multi-node --build-arg OVS_SRC_PATH=ovs \
     --build-arg OVN_SRC_PATH=ovn --build-arg USE_OVN_RPMS=${USE_OVN_RPMS} \
     --build-arg EXTRA_OPTIMIZE=${EXTRA_OPTIMIZE} \
+    --build-arg INSTALL_UTILS_FROM_SOURCES=${INSTALL_UTILS_FROM_SOURCES} \
     -f  fedora/ovn/Dockerfile .
 }
 


### PR DESCRIPTION
This patch compiles "uperf" from sources. The code to compile uperf
is taken from Eelco Chaudron's private branch of ovn-fake-multinode git repo.
(https://github.com/chaudron/ovn-fake-multinode)

This is optional and disabled by default. User has to set the env 'INSTALL_UTILS_FROM_SOURCES'
to 'yes' to enable it.

Signed-off-by: Numan Siddique <numans@ovn.org>