### PR TITLE
Fix cinc/Dockerfile.

### DIFF
--- a/fedora/cinc/Dockerfile
+++ b/fedora/cinc/Dockerfile
@@ -21,6 +21,9 @@
 ARG OS_IMAGE
 FROM $OS_IMAGE
 
+# Pass OS_IMAGE to build scripts too.
+ARG OS_IMAGE
+
 # Fix 'WARNING: terminal is not fully functional' when TERM=dumb
 ENV TERM=xterm
 


### PR DESCRIPTION
OS_IMAGE ARG must be repeated if it will be used in the build stage [0].

[0] https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

Fixes: c5ad3c356d7d ("improve code to support rhel")
Signed-off-by: Dumitru Ceara <dceara@redhat.com>