### PR TITLE
Silence `ls` command

### DIFF
--- a/fedora/cinc/Dockerfile
+++ b/fedora/cinc/Dockerfile
@@ -41,7 +41,7 @@ RUN /install_pkg.sh $OS_IMAGE
 COPY dbus.service /etc/systemd/system/
 
 
-RUN pip3 install six
+RUN pip3 -qq install six
 
 
 RUN mkdir -p /usr/local/bin

--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -115,6 +115,7 @@ yum -y --skip-broken install\
 	fping\
 	perf\
 	git\
+	file\
 	lksctp-tools-devel\
 	hostname
 

--- a/fedora/cinc/rhel7-Dockerfile
+++ b/fedora/cinc/rhel7-Dockerfile
@@ -37,7 +37,7 @@ RUN /install_pkg.sh $OS_IMAGE
 COPY dbus.service /etc/systemd/system/
 
 
-RUN pip3 install six
+RUN pip3 -qq install six
 
 
 RUN mkdir -p /usr/local/bin

--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -705,7 +705,7 @@ function build-images() {
 
 function check-for-ovn-rpms() {
     USE_OVN_RPMS=yes
-    ls ovn*.rpm || USE_OVN_RPMS=no
+    ls ovn*.rpm > /dev/null 2>&1 || USE_OVN_RPMS=no
 }
 
 function build-images-with-ovn-rpms() {


### PR DESCRIPTION
The `ls` command's output looks like an error.

"ls: cannot access 'ovn*.rpm': No such file or directory"

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>