### PR TITLE
Suppress pip3 warning as we need to install as root

### DIFF
--- a/fedora/cinc/Dockerfile
+++ b/fedora/cinc/Dockerfile
@@ -41,7 +41,7 @@ RUN /install_pkg.sh $OS_IMAGE
 COPY dbus.service /etc/systemd/system/
 
 
-RUN pip3 install six
+RUN pip3 -q install six
 
 
 RUN mkdir -p /usr/local/bin


### PR DESCRIPTION
"WARNING: Running pip install with root privileges is generally
not a good idea. Try `pip3 install --user` instead."

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>