### PR TITLE
Install "file" dependency

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -115,6 +115,7 @@ yum -y --skip-broken install\
 	fping\
 	perf\
 	git\
+	file\
 	lksctp-tools-devel\
 	hostname
 


### PR DESCRIPTION
Fixes warning:

"./configure: line 8621: /usr/bin/file: No such file or directory"

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>