### PR TITLE
install_pkg.sh: install systemctl before attempting to use

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -1,6 +1,8 @@
 
 image_name=${1:-"fedora:31"}
 
+yum -y install systemd
+
 systemctl mask \
 	auditd.service\
 	console-getty.service\


### PR DESCRIPTION
to avoid the following error while building cinc image:

 ---> Running in a4558a59790f
 /install_pkg.sh: line 4: systemctl: command not found
 /install_pkg.sh: line 89: systemctl: command not found