### PR TITLE
Vagrant: fix nesting and docker install

### DIFF
--- a/provisioning/enable_nesting.sh
+++ b/provisioning/enable_nesting.sh
@@ -4,12 +4,13 @@ set -o errexit
 #set -o xtrace
 
 [ -e /dev/kvm ] || { echo "PROBLEM, you need to ensure hv can nest"; exit 1; }
-grep -q Y /sys/module/kvm_intel/parameters/nested || {
+grep -q Y /sys/module/kvm_intel/parameters/nested || \
+grep -q 1 /sys/module/kvm_intel/parameters/nested || {
   sudo rmmod kvm-intel
   sudo sh -c "echo 'options kvm-intel nested=y' >> /etc/modprobe.d/dist.conf"
   sudo modprobe kvm-intel
 }
 [ -e /sys/module/kvm_intel ] && {
-  modinfo kvm_intel | grep -q 'nested:bool' || { echo "PROBLEM, nesting did not enable"; exit 1; }
+  modinfo kvm_intel | grep -q 'nested:' || { echo "PROBLEM, nesting did not enable"; exit 1; }
 } ||:
 

--- a/provisioning/install_docker.sh
+++ b/provisioning/install_docker.sh
@@ -7,14 +7,7 @@ set -o errexit
 
 # Ref: https://linuxconfig.org/how-to-install-docker-in-rhel-8
 dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-
-# We can get docker to work on Centos 8 in of these 2 ways
-if false; then
-    dnf install -y --nobest docker-ce
-else
-    dnf install -y docker-ce-3:18.09.1-3.el7
-    dnf install -y https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
-fi
+dnf install -y docker-ce
 
 [ -d /home/vagrant ] && usermod -a -G docker vagrant
 


### PR DESCRIPTION
Fix enable_nesting.sh so it works on newer kernels.
Remove work around in install_docker.sh (no longer needed)