### PR TITLE
ovn_cluster/count-containers: remove whitespace from container name

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -99,8 +99,11 @@ function count-gw() {
 function count-containers() {
   local name=$1
   local filter=${2:-}
-
   local count=0
+
+  # remove any whitespace from the container name
+  name=$(echo $name | sed 's/ //g')
+
   for cid in $( ${RUNC_CMD} ps -qa --filter "name=${name}" $filter); do
     (( count += 1 ))
   done


### PR DESCRIPTION
when validating the container status on function count-containers
if the name of the container contains any whitespace the container will not be found
by count-containers, and that causes the functions that use count-containers
to run forever and waiting for the desired container to become up.

so we must remove the extra whitespace from the container name if exist.

Signed-off-by: Mohammad Heib <mheib@redhat.com>
Signed-off-by: Mohammad Heib <goody698@gmail.com>