### PR TITLE
Correct the default gateway address for ovnfake-ext.

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -725,7 +725,7 @@ EOF
     ip netns exec ovnfake-ext ip addr add 172.16.0.50/24 dev ovnfake-ext
     ip netns exec ovnfake-ext ip addr add 3000::b/64 dev ovnfake-ext
     ip netns exec ovnfake-ext ip link set ovnfake-ext up
-    ip netns exec ovnfake-ext ip route add default via 172.16.0.1
+    ip netns exec ovnfake-ext ip route add default via 172.16.0.100
 
     echo "Creating a fake VM in the ovs bridge ${OVN_BR}"
     ip netns add ovnfake-int


### PR DESCRIPTION
The lr0 public interface has address 172.16.0.100, but ovnfake-ext was
setting its default gateway to 172.16.0.1, which does not exist in the
default cluster that ovn_cluster creates.

This change updates the default gatewaay to 172.16.0.100.

Signed-off-by: Mark Michelson <mmichels@redhat.com>