### PR TITLE
Add very basic CI

### DIFF
--- a/.ci/test_basic.sh
+++ b/.ci/test_basic.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -xe
+
+# Simple configuration sanity checks
+podman exec -it ovn-central ovn-nbctl show > nb_show
+podman exec -it ovn-central ovn-sbctl show > sb_show
+
+grep "(public)" nb_show
+grep "(sw0)" nb_show
+grep "(sw1)" nb_show
+grep "(lr0)" nb_show
+
+
+grep "Chassis ovn-gw-1" sb_show
+grep "Chassis ovn-chassis-1" sb_show
+grep "Chassis ovn-chassis-2" sb_show
+
+
+# Some pings between the containers
+podman exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.2
+podman exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.3
+podman exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.5
+
+podman exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.2
+podman exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.3
+podman exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.4
+
+podman exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.2
+podman exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.4
+podman exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  basic:
+    env:
+      RUNC_CMD: podman
+      OVN_SRC_PATH: ovn_git
+      OVS_SRC_PATH: ovn_git/ovs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download ovn-fake-multinode
+        uses: actions/checkout@v3
+      - name: Download OVN main
+        uses: actions/checkout@v3
+        with:
+          repository: ovn-org/ovn
+          path: ovn_git
+          fetch-depth: 1
+          submodules: true
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install podman openvswitch-switch
+      - name: Build images
+        run: sudo -E ./ovn_cluster.sh build
+      - name: Start basic cluster
+        run: sudo -E ./ovn_cluster.sh start
+      - name: Run basic test script
+        run: sudo ./.ci/test_basic.sh
+      - name: Stop cluster
+        run: sudo -E ./ovn_cluster.sh stop


### PR DESCRIPTION
As a sanity check that everything still works add basic CI.
The goal is to build and start the cluster and within the
cluster check that the configuration works with very basic
tests.

Signed-off-by: Ales Musil <amusil@redhat.com>