### PR TITLE
Return --skip-broken for dnf install 

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -16,7 +16,7 @@ systemctl mask \
 	systemd-udevd.service \
 	systemd-vconsole-setup.service
 
-dnf -y install \
+dnf -y --skip-broken install \
   autoconf \
   automake \
   conntrack-tools \


### PR DESCRIPTION
Some of the packages are not available on ubi8,
but available and used by default configuration
with fedora image. Return the --skip-broken
to keep them compatible.

Signed-off-by: Ales Musil <amusil@redhat.com>