### PR TITLE
Add missing iputils

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -30,7 +30,7 @@ dnf -y --skip-broken install \
   glibc-langpack-en \
   hostname \
   iproute \
-  iproute.x86_64 \
+  iputils \
   iptables \
   libcap-devel \
   libreswan \


### PR DESCRIPTION
During the cleanup there was iproute mentioned twice and
iputils was gone. Replace the second iproute with iputils.

Signed-off-by: Ales Musil <amusil@redhat.com>