### PR TITLE
install_pkg.sh add missing dhcp network configuration script

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -54,3 +54,7 @@ dnf -y --skip-broken install \
   tcpdump \
   uuid.x86_64 \
   which
+
+# Generate variation of dhclient-script that we can use for fake vm namespaces
+mkdir -pv /bin
+/tmp/generate_dhclient_script_for_fullstack.sh /


### PR DESCRIPTION
dhclient uses /bin/fullstack-dhclient-script script as a
network configuration script, this script are used to configure
ovn port with dynamic addresses.

Fixes: 630145022ca5 (Refactor the install_pkg script)
Signed-off-by: Mohammad Heib <mheib@redhat.com>