### PR TITLE
test_basic.sh: enhance basic CI

### DIFF
--- a/.ci/test_basic.sh
+++ b/.ci/test_basic.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -xe
 
+PODMAN_BIN=${1:-podman}
+
 # Simple configuration sanity checks
-podman exec -it ovn-central ovn-nbctl show > nb_show
-podman exec -it ovn-central ovn-sbctl show > sb_show
+$PODMAN_BIN exec -it ovn-central ovn-nbctl show > nb_show
+$PODMAN_BIN exec -it ovn-central ovn-sbctl show > sb_show
 
 grep "(public)" nb_show
 grep "(sw0)" nb_show
@@ -16,14 +18,30 @@ grep "Chassis ovn-chassis-2" sb_show
 
 
 # Some pings between the containers
-podman exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.2
-podman exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.3
-podman exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.5
+$PODMAN_BIN exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.2
+$PODMAN_BIN exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.3
+$PODMAN_BIN exec -it ovn-chassis-1 ping -c 1 -w 1 170.168.0.5
 
-podman exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.2
-podman exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.3
-podman exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.4
+$PODMAN_BIN exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.2
+$PODMAN_BIN exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.3
+$PODMAN_BIN exec -it ovn-chassis-2 ping -c 1 -w 1 170.168.0.4
 
-podman exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.2
-podman exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.4
-podman exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.5
+$PODMAN_BIN exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.2
+$PODMAN_BIN exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.4
+$PODMAN_BIN exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.5
+
+
+# Check expected routes from nested namespaces
+
+$PODMAN_BIN exec -it ovn-chassis-1 ip netns
+
+# sw0p1 : dual stack
+$PODMAN_BIN exec -it ovn-chassis-1 ip netns exec sw0p1 ip -4 route > sw0p1_route
+$PODMAN_BIN exec -it ovn-chassis-1 ip netns exec sw0p1 ip -6 route >> sw0p1_route
+cat sw0p1_route
+grep "10.0.0.0/24 dev sw0p1" sw0p1_route
+grep "default via 10.0.0.1 dev sw0p1" sw0p1_route
+grep "1000::/64 dev sw0p1" sw0p1_route
+grep "default via 1000::a dev sw0p1" sw0p1_route
+
+echo 'happy happy, joy joy'


### PR DESCRIPTION
Improve test_basic.sh to ensure specific LSPs came up
by checking the routes in the nested namespaces.

**NOTE:** The datapath in ci deployment is somewhat limited, so testing traffic from lsp does not work as is.
 

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>