### PR TITLE
cinc: Install python3-psutil.

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -50,6 +50,7 @@ dnf -y --skip-broken install \
   procps-ng \
   python3 \
   python3-pip \
+  python3-psutil \
   resource-agents \
   tcpdump \
   uuid.x86_64 \


### PR DESCRIPTION
Resource usage monitoring in ovn-heater will need that package to
run python-based monitoring script inside of a container.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>