### PR TITLE
cinc: Don't abort if we can't prepare the dhclient-script.

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -57,6 +57,9 @@ dnf -y --skip-broken install \
   which  \
   initscripts
 
-# Generate variation of dhclient-script that we can use for fake vm namespaces
+# Generate variation of dhclient-script that we can use for fake vm namespaces.
+# dhclient-script might not be available though, so don't fail if that's
+# the case.
 mkdir -pv /bin
-/tmp/generate_dhclient_script_for_fullstack.sh /
+/tmp/generate_dhclient_script_for_fullstack.sh / || \
+    echo "Failed to generate dhclient script for fullstack!"


### PR DESCRIPTION
On some platforms dhcp-client is not available by default (e.g., RHEL
UBI 8.5).  This means we won't be able to use the fake VM scripts but we
can still use ovn-fake-multinode for other types of testing.