### PR TITLE
install_ovn: Don't try to distclean when using RPMs.

### DIFF
--- a/install_ovn.sh
+++ b/install_ovn.sh
@@ -76,9 +76,11 @@ popd
 dnf autoremove -y
 
 # Clean all object files
-cd /ovs
-make distclean
-cd /ovn
-make distclean
-cd ./ovs
-make distclean
+if [ "$use_ovn_rpm" = "no" ]; then
+    cd /ovs
+    make distclean
+    cd /ovn
+    make distclean
+    cd ./ovs
+    make distclean
+fi


### PR DESCRIPTION
Otherwise when installing:

````
+ cd /ovs
+ make distclean
make: *** No rule to make target 'distclean'.  Stop.
````