### PR TITLE
install_ovn.sh: Add a blank line.

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -2,6 +2,7 @@
 
 [ $EUID -eq 0 ] || { echo 'must be root' >&2; exit 1; }
 
+
 #set -o xtrace
 set -o errexit
 


### PR DESCRIPTION
I'm doing this because I suspect the github actions are broken for ovn-fake-multinode. I've literally added a blank line to a script. If this causes checks to fail, the checks are broken.