### PR TITLE
install_ovn.sh: Fix broken build on RHEL due to missing pip.

### DIFF
--- a/install_ovn.sh
+++ b/install_ovn.sh
@@ -80,7 +80,7 @@ pushd python
 python3 setup.py build_ext -I /ovs/include -L /ovs/lib/.libs
 so_file=$(find build -name _json*.so)
 cp "$so_file" ovs/
-pip install -e .
+python3 -m pip install -e .
 popd #python
 popd #/opt/ovn
 


### PR DESCRIPTION
Not all distributions have 'pip' binary.  Some have 'pip3' only. And the better option is to use 'python3 -m pip' instead to be compatible.

Signed-off-by: Ilya Maximets \<i.maximets@ovn.org\>