### PR TITLE
install_ovn.sh: Avoid dynamic linking and fix build with RPMs.

### DIFF
--- a/install_ovn.sh
+++ b/install_ovn.sh
@@ -19,9 +19,9 @@ use_ovn_rpm=$1
 extra_optimize=$2
 
 if [ "$extra_optimize" = "yes" ]; then
-    cflags='-g -march=native -O3 -fno-omit-frame-pointer'
+    cflags='-g -march=native -O3 -fno-omit-frame-pointer -fPIC'
 else
-    cflags='-g -O2 -fno-omit-frame-pointer'
+    cflags='-g -O2 -fno-omit-frame-pointer -fPIC'
 fi
 
 if [ "$use_ovn_rpm" = "yes" ]; then
@@ -34,10 +34,20 @@ else
     cd /ovs
     ./boot.sh
     ./configure --localstatedir="/var" --sysconfdir="/etc" --prefix="/usr" \
-    --enable-ssl --disable-libcapng --enable-Werror --enable-shared CFLAGS="${cflags}"
+        --enable-ssl --disable-libcapng --enable-Werror CFLAGS="${cflags}"
     make -j$(($(nproc) + 1)) V=0
     make install
     cp ./ovsdb/_server.ovsschema /root/ovsdb-etcd/schemas/
+
+    # Install python IDL with built-in C extensions.
+    dnf install -y python3-devel python3-wheel
+    pushd /ovs/python
+    pkgcfg_libs="`pkg-config --libs --static libopenvswitch`"
+    enable_shared=no \
+      extra_cflags="`pkg-config --cflags libopenvswitch`" \
+      extra_libs="-Wl,-Bstatic -lopenvswitch -Wl,-Bdynamic ${pkgcfg_libs}" \
+      python3 -m pip install --verbose --compile .
+    popd #/ovs/python
 
     # Build OVS libraries from submodule, needed by OVN.
     cd /ovn
@@ -71,18 +81,6 @@ $OVS_PKI init
 pushd /opt/ovn
 $OVS_PKI req+sign ovn switch
 popd
-
-# Install python IDL
-dnf install -y python3-devel
-pushd /opt/ovn
-cp -r /ovs/python .
-pushd python
-python3 setup.py build_ext -I /ovs/include -L /ovs/lib/.libs
-so_file=$(find build -name _json*.so)
-cp "$so_file" ovs/
-python3 -m pip install -e .
-popd #python
-popd #/opt/ovn
 
 # remove unused packages to make the container light weight.
 dnf autoremove -y


### PR DESCRIPTION
Dynamic linking of ovsdb-server may cause skewed performance results in comparison with previous runs in ovn-heater.
Building OVS statically and also linking the C extension statically instead.

Using pkg-config to get the correct build flags.  Installing using pip.  It will build the extension as well.  Additionally pre-compiling python sources.

'-fPIC' is added to compiler flags to make the static linkage possible.

Signed-off-by: Ilya Maximets \<i.maximets@ovn.org\>