### PR TITLE
install_ovn.sh: Don't try to install python3-wheel.

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -49,6 +49,7 @@ dnf -y --skip-broken install \
   perf \
   procps-ng \
   python3 \
+  python3-devel \
   python3-pip \
   python3-psutil \
   resource-agents \

--- a/install_ovn.sh
+++ b/install_ovn.sh
@@ -40,7 +40,6 @@ else
     cp ./ovsdb/_server.ovsschema /root/ovsdb-etcd/schemas/
 
     # Install python IDL with built-in C extensions.
-    dnf install -y python3-devel python3-wheel
     pushd /ovs/python
     pkgcfg_libs="`pkg-config --libs --static libopenvswitch`"
     enable_shared=no \


### PR DESCRIPTION
It's not available on all distros.  Moreover, we don't need it for compiling the python ovs IDL.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>