### PR TITLE
Use veth instead of ovs internal port for fake vms.

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -707,11 +707,14 @@ create_fake_vm() {
     ipv6_addr=\$7
     ipv6_gw=\$8
     ip netns add \$name
-    ovs-vsctl \
-      -- add-port br-int \$name \
-      -- set interface \$name type=internal \
-      -- set Interface \$name external_ids:iface-id=\$iface_id
+    ip link add \$name-p type veth peer name \$name
     ip link set \$name netns \$name
+    ip netns exec \$name ip link set lo up
+    ip link set \$name-p up
+
+    ovs-vsctl \
+      -- add-port br-int \$name-p \
+      -- set Interface \$name-p external_ids:iface-id=\$iface_id
     ip netns exec \$name ip link set lo up
     [ -n "\$mac" ] && ip netns exec \$name ip link set \$name address \$mac
     if [ "\$ip" == "dhcp" ]; then


### PR DESCRIPTION
This is more realistic.  ovn-k8s CNI creates veths for pods.

Signed-off-by: Numan Siddique <numans@ovn.org>