### PR TITLE
install_ovn.sh: Add js-d3-flame-graph package

### DIFF
--- a/fedora/cinc/install_pkg.sh
+++ b/fedora/cinc/install_pkg.sh
@@ -32,6 +32,7 @@ dnf -y --skip-broken install \
   iproute \
   iputils \
   iptables \
+  js-d3-flame-graph \
   libcap-devel \
   libreswan \
   libtool \


### PR DESCRIPTION
The js-d3-flame-graph package provides a template
for perf flamegraph. It increases the overall size of the container just by 425 kB.