### PR TITLE
Use OVS main branch.

### DIFF
--- a/provisioning/grab_ovn_src.sh
+++ b/provisioning/grab_ovn_src.sh
@@ -14,7 +14,7 @@ function grab_src {
 }
 
 OVS_GIT_REPO=${OVS_GIT_REPO:-https://github.com/openvswitch/ovs}
-OVS_BRANCH=${OVS_BRANCH:-master}
+OVS_BRANCH=${OVS_BRANCH:-main}
 OVN_GIT_REPO=${GIT_REPO:-https://github.com/ovn-org/ovn}
 OVN_BRANCH=${OVN_BRANCH:-main}
 


### PR DESCRIPTION
The OpenvSwitch project changed the default branch to "main".