### PR TITLE
Fix ubuntu image build on 24.04 + fix tests on latest fedora.

### DIFF
--- a/.ci/test_basic.sh
+++ b/.ci/test_basic.sh
@@ -36,8 +36,10 @@ $PODMAN_BIN exec -it ovn-gw-1 ping -c 1 -w 1 170.168.0.5
 $PODMAN_BIN exec -it ovn-chassis-1 ip netns
 
 # sw01p1 : dual stack
-$PODMAN_BIN exec -it ovn-chassis-1 ip netns exec sw01p1 ip -4 route > sw01p1_route
-$PODMAN_BIN exec -it ovn-chassis-1 ip netns exec sw01p1 ip -6 route >> sw01p1_route
+$PODMAN_BIN exec -it ovn-chassis-1 \
+    ip netns exec sw01p1 ip --color=never -4 route > sw01p1_route
+$PODMAN_BIN exec -it ovn-chassis-1 \
+    ip netns exec sw01p1 ip --color=never -6 route >> sw01p1_route
 cat sw01p1_route
 grep "11.0.0.0/24 dev sw01p1" sw01p1_route
 grep "default via 11.0.0.1 dev sw01p1" sw01p1_route

--- a/image/cinc/install_ubuntu_pkg.sh
+++ b/image/cinc/install_ubuntu_pkg.sh
@@ -41,7 +41,7 @@ apt install -yq --no-install-recommends \
   python3-pip \
   python3-psutil \
   python3-six \
-  resource-agents \
+  resource-agents* \
   tcpdump \
   uuid
 


### PR DESCRIPTION
Ubuntu container fails to build on 24.04:

```
  Package resource-agents is not available, but is referred to by
  another package.  This may mean that the package is missing, has
  been obsoleted, or is only available from another source
  However the following packages replace it:
    resource-agents-extra resource-agents-common resource-agents-base
```

And latest fedora is using `ip --color=auto` as a default alias and that breaks the grep in the tests.