### PR TITLE
Add --may-exist parameter to addition of ts

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -819,7 +819,7 @@ EOF
     chmod 0755 ${FAKENODE_MNT_DIR}/create_ovn_res.sh
 
     # add ts transit switch.
-    ${RUNC_CMD} exec ${CENTRAL_IC_ID} ovn-ic-nbctl ts-add ts1
+    ${RUNC_CMD} exec ${CENTRAL_IC_ID} ovn-ic-nbctl --may-exist ts-add ts1
     # wait for ovn-ic to kick in
     while sleep 2; do
         ${RUNC_CMD} exec ${CENTRAL_IC_ID} ovn-nbctl ls-list | grep -q ts1 && break


### PR DESCRIPTION
Without --may-exist, ovn-ic-nbctl ts-add ts1 could return error and doesn't execute the following steps of function.
This problem occurs when CENTRAL_COUNT is greater than 1 because create_fake_vms will be called more than once.

Here it's a example to see the problem:
OS_BASE=ubuntu OS_IMAGE=docker.io/library/ubuntu:jammy ENABLE_SSL=no CENTRAL_COUNT=3 GW_COUNT=3 CHASSIS_COUNT=3 ./ovn_cluster.sh start