### PR TITLE
Fix missing change name ovn central in function start-ovn-ic 

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -516,7 +516,11 @@ function start-db-cluster() {
 function start-ovn-ic() {
     if [ "$OVN_START_IC_DBS" = "yes" ]; then
         if [ -z "$CENTRAL_IC_ID" ]; then
-            CENTRAL_IC_ID="${CENTRAL_NAMES[0]}"-1
+            if [ "$OVN_DB_CLUSTER" = "yes" ]; then
+                CENTRAL_IC_ID="${CENTRAL_NAMES[0]}"-1
+            else
+                CENTRAL_IC_ID="${CENTRAL_NAMES[0]}"
+            fi
         fi
 
         ${RUNC_CMD} exec $CENTRAL_IC_ID ${OVNCTL_PATH}  \


### PR DESCRIPTION
function start-ovn-ic must check if OVN_DB_CLUSTER is being used to set CENTRAL_IC_ID name.
Running the following command, you will see the problem: OS_BASE=ubuntu OS_IMAGE=docker.io/library/ubuntu:jammy ENABLE_SSL=no CENTRAL_COUNT=1 GW_COUNT=4 CHASSIS_COUNT=4 ./ovn_cluster.sh start

It creates ovn central with name ovn-central-az1, and function try to use ovn-central-az1-1