### PR TITLE
ovn_cluster: Fix CENTRAL_IC_ID default value

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -516,7 +516,7 @@ function start-db-cluster() {
 function start-ovn-ic() {
     if [ "$OVN_START_IC_DBS" = "yes" ]; then
         if [ -z "$CENTRAL_IC_ID" ]; then
-            CENTRAL_IC_ID="${CENTRAL_NAMES[0]}"-1
+            CENTRAL_IC_ID="${CENTRAL_NAMES[0]}"
         fi
 
         ${RUNC_CMD} exec $CENTRAL_IC_ID ${OVNCTL_PATH}  \


### PR DESCRIPTION
Set default value for CENTRAL_IC_ID to ${CENTRAL_NAMES[0]}. This patch fix the following error when CENTRAL_IC_ID is not provided by the user:

Error: no container with name or ID "ovn-central-az1-1" found: no such container

Tested-by: Aaron Conole <aconole@redhat.com>
Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>