### PR TITLE
Add frr to list of packages.

### DIFF
--- a/image/cinc/install_fedora_pkg.sh
+++ b/image/cinc/install_fedora_pkg.sh
@@ -24,6 +24,7 @@ dnf install -y --skip-broken \
   dnf-utils \
   file \
   fping \
+  frr \
   gcc \
   gettext-devel \
   git \

--- a/image/cinc/install_ubuntu_pkg.sh
+++ b/image/cinc/install_ubuntu_pkg.sh
@@ -12,6 +12,7 @@ apt install -yq --no-install-recommends \
   isc-dhcp-client \
   file \
   fping \
+  frr \
   gcc \
   gettext \
   git \


### PR DESCRIPTION
Adds frr as a bgp agent for use with ovn and its bgp capabilities. Added in light of the upcoming addition of a multinode test to the ovn multinode testsuite.