### PR TITLE
ovn_cluster: Disable DAD for fake VM.

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -879,7 +879,7 @@ create_fake_vm() {
       ip netns exec \$name dhclient -sf /bin/fullstack-dhclient-script --no-pid -nw \$name
     else
       ip netns exec \$name ip addr add \$ip/\$mask dev \$name
-      ip netns exec \$name ip addr add \$ipv6_addr dev \$name
+      ip netns exec \$name ip addr add \$ipv6_addr dev \$name "nodad"
       ip netns exec \$name ip link set \$name up
       ip netns exec \$name ip route add default via \$gw dev \$name
       ip netns exec \$name ip -6 route add default via \$ipv6_gw dev \$name


### PR DESCRIPTION
Disable IPv6 DAD for fake VM, it can cause flakes as the interface might not be ready in time due to duplicate detection.