### PR TITLE
cinc: Remove unused resource-agents package.

### DIFF
--- a/image/cinc/install_fedora_pkg.sh
+++ b/image/cinc/install_fedora_pkg.sh
@@ -55,7 +55,6 @@ dnf install -y --skip-broken \
   python3-pip \
   python3-psutil \
   python3-six \
-  resource-agents \
   tcpdump \
   unbound-devel \
   uuid.x86_64 \

--- a/image/cinc/install_ubuntu_pkg.sh
+++ b/image/cinc/install_ubuntu_pkg.sh
@@ -52,7 +52,6 @@ apt install -yq --no-install-recommends \
   python3-psutil \
   python3-six \
   python3-systemd \
-  resource-agents* \
   tcpdump \
   netcat-traditional \
   uuid


### PR DESCRIPTION
The package was leftover from the beginning, it's not used for anything. Quite the contrary the resource-agents on Ubuntu did pull corosync which was consuming large amounts of RAM. Remove that package from both Ubuntu and Fedora.