### PR TITLE
ovn_cluster.sh: fix external bridge creation check

### DIFF
--- a/ovn_cluster.sh
+++ b/ovn_cluster.sh
@@ -206,7 +206,7 @@ function stop() {
 
 function setup-ovs-in-host() {
     ovs-vsctl br-exists $OVN_BR || ovs-vsctl add-br $OVN_BR || exit 1
-    ovs-vsctl br-exists $OVN_BR || ovs-vsctl add-br $OVN_EXT_BR || exit 1
+    ovs-vsctl br-exists $OVN_EXT_BR || ovs-vsctl add-br $OVN_EXT_BR || exit 1
 }
 
 function add-ovs-container-ports() {


### PR DESCRIPTION
`setup-ovs-in-host` was checking for `OVN_BR` before creating `OVN_EXT_BR`, so `br-ovn-ext` could be skipped once `br-ovn` already existed. This updates the check to match the bridge being created.
