### PR TITLE
github: Workaround broken Ubuntu 24.04 podman version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install podman openvswitch-switch
+          sudo apt install openvswitch-switch
+          podman --version
       - name: Build images
         run: sudo -E ./ovn_cluster.sh build
       - name: Start basic cluster


### PR DESCRIPTION
With the current GitHub Actions Ubuntu 24.04 runner, exec-ing into a
running container often hangs.  This started happening after the runner
image was upgraded to 20260810.271 which bumped podman 4.9.3 to 5.8.4.
    
This was reported as a actions/runner-images issue here:
https://github.com/actions/runner-images/issues/14604
    
Instead of waiting for the image fix, avoid installing the broken
podman, the good version is already installed in the immage.  Suggested
as a workaround here:
https://github.com/actions/runner-images/issues/14604#issuecomment-5407848794
